### PR TITLE
small fix for timeblock date calc

### DIFF
--- a/src/app/api/duey/chat/route.ts
+++ b/src/app/api/duey/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { dueySystemPrompt } from "@/duey-engine/prompt/main";
 import { timeblockToolPrompt } from "@/duey-engine/prompt/tool-prompt/timeblock";
+import { getCurrentDateString } from "@/duey-engine/prompt/helpers/getCurrentDateString";
 import { detectToolIntent } from "./helpers/toolDetection";
 import { db } from "@/db";
 import { users } from "@/db/schema/user";
@@ -232,8 +233,9 @@ export const POST = withAuthRequired(async (request: NextRequest, context) => {
     console.log("[Duey Chat] Timeblock intent detected:", isTimeblockIntent);
     console.log("[Duey Chat] Using prompt:", isTimeblockIntent ? "timeblockToolPrompt" : "dueySystemPrompt");
 
-    const systemPrompt = isTimeblockIntent
-      ? timeblockToolPrompt(userTimezone)
+    const today = getCurrentDateString(userTimezone);
+const systemPrompt = isTimeblockIntent
+      ? timeblockToolPrompt(userTimezone) + `\n\nToday is ${today}.`
       : dueySystemPrompt(
           userTimezone,
           formatClassesForPrompt(classes, nowIso),

--- a/src/duey-engine/prompt/helpers/getCurrentDateString.ts
+++ b/src/duey-engine/prompt/helpers/getCurrentDateString.ts
@@ -1,0 +1,3 @@
+export function getCurrentDateString(timezone: string): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: timezone });
+}

--- a/src/duey-engine/prompt/main.ts
+++ b/src/duey-engine/prompt/main.ts
@@ -16,11 +16,6 @@ export const dueySystemPrompt = (
   - timeblocks
   - flashcards
 
-**Tool Usage Guidance:**
-  - If a user's request matches a tool you have access to (like timeblock creation), respond with a structured JSON action for that tool (see timeblock tool prompt for schema).
-  - For example, if the user wants to schedule or block off time, respond with a JSON block for timeblock creation.
-  - The backend will detect and route these actions to the correct API.
-
 **Capabilities:**
   - Analyze assignments and suggest study timeblocks
   - Create timeblocks automatically when appropriate

--- a/src/duey-engine/prompt/tool-prompt/timeblock.ts
+++ b/src/duey-engine/prompt/tool-prompt/timeblock.ts
@@ -9,12 +9,13 @@ When suggesting study time, you can create timeblocks by responding with:
       "timeblock": {
         "title": "Study for Math Exam",
         "description": "Review chapters 5-7 and practice problems",
-        "startTime": "2024-01-15T14:00:00Z",
-        "endTime": "2024-01-15T15:30:00Z",
+        "startTime": "<startTime>",
+        "endTime": "<endTime>",
         "type": "study",
         "classId": "optional-class-id"
       }
     }
+    // Replace <startTime> and <endTime> with the user's intended date/time in ISO 8601 format. If the user does not specify a date, use today's date in the user's timezone as reference.
 
 **Timezone:**
 - All times referenced by the user are in their local timezone: ${userTimezone}.


### PR DESCRIPTION
this is so duey knows the current date for context when building time blocks for "tomorrow" "next week", etc. 